### PR TITLE
🐛📝 fix: setup script container down issue and docs update

### DIFF
--- a/sample-applications/video-summarization/docker/compose.base.yaml
+++ b/sample-applications/video-summarization/docker/compose.base.yaml
@@ -26,7 +26,7 @@ services:
 
   vss-ui:
     build:
-      context: ui/react
+      context: ../ui/react
       dockerfile: Dockerfile
     image: ${REGISTRY:-}vss-ui:${TAG:-latest}
     ipc: host
@@ -48,7 +48,7 @@ services:
 
   pipeline-manager:
     build:
-      context: pipeline-manager
+      context: ../pipeline-manager
       dockerfile: Dockerfile
     image: ${REGISTRY:-}pipeline-manager:${TAG:-latest}
     ports:

--- a/sample-applications/video-summarization/docker/compose.base.yaml
+++ b/sample-applications/video-summarization/docker/compose.base.yaml
@@ -9,7 +9,7 @@ services:
       no_proxy: ${no_proxy},${MINIO_HOST},vss-ui,pipeline-manager
       APP_UI: vss-ui
       APP_MANAGER: pipeline-manager:3000
-      APP_ASSETS: ${MINIO_HOST}
+      APP_ASSETS: minio-service
       NGINX_ENVSUBST_TEMPLATE_DIR: /etc/nginx/templates
       NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
     volumes:

--- a/sample-applications/video-summarization/docker/compose.search.yaml
+++ b/sample-applications/video-summarization/docker/compose.search.yaml
@@ -24,7 +24,7 @@ services:
   video-search:
     image: ${REGISTRY:-}video-search:${TAG:-latest}
     build:
-      context: search-ms
+      context: ../search-ms
       dockerfile: docker/Dockerfile
     depends_on:
       vdms-vector-db:

--- a/sample-applications/video-summarization/docs/user-guide/get-started.md
+++ b/sample-applications/video-summarization/docs/user-guide/get-started.md
@@ -28,17 +28,18 @@ sample-applications/video-summarization/
 ├── config                     # Configuration files
 │   ├── nginx.conf             # Nginx configuration
 │   └── rmq.conf               # RabbitMQ configuration
-├── data                       # Data directory for video files
 ├── docker                     # Docker compose files
 │   ├── compose.base.yaml      # Base services configuration
-│   ├── compose.summary.yaml   # Video summarization services
-│   ├── compose.search.yaml    # Video search services 
+│   ├── compose.summary.yaml   # Compose override file for video summarization services
+│   ├── compose.search.yaml    # Compose override file for Video search services 
 │   ├── compose.gpu_vlm.yaml   # GPU configuration for VLM
 │   └── compose.gpu_ovms.yaml  # GPU configuration for OVMS
 ├── docs                       # Documentation
-├── ov_models                  # OpenVINO models directory
-├── pipeline-manager           # Maintains state of all operations
-├── ui                         # Video Summary UI code
+│   └── user-guide             # User guides and tutorials
+├── pipeline-manager           # Backend service which orchestrates the Video Summarization and Search
+├── search-ms                  # Video Search Microservice
+├── ui                         # Video Summary and Search UI code
+├── build.sh                   # Script for building application images
 ├── setup.sh                   # Setup script for environment and deployment
 └── README.md                  # Project documentation
 ```

--- a/sample-applications/video-summarization/setup.sh
+++ b/sample-applications/video-summarization/setup.sh
@@ -7,6 +7,13 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Setting variables for directories used as volume mounts. Could be required during stopping containers as well.
+export OVMS_CONFIG_DIR=${PWD}/config/ovms_config
+export OV_MODEL_DIR=${PWD}/ov_models
+export CONFIG_DIR=${PWD}/config
+export NGINX_CONFIG=${CONFIG_DIR}/nginx.conf
+export RABBITMQ_CONFIG=${CONFIG_DIR}/rmq.conf
+
 # Setting command usage and invalid arguments handling before the actual setup starts
 if [ "$#" -eq 0 ] ||  ([ "$#" -eq 1 ] && [ "$1" = "--help" ]); then
     # If no valid argument is passed, print usage information
@@ -49,8 +56,13 @@ elif [ "$#" -eq 2 ] && [ "$2" = "config" ] && [ "$1" != "--summary" ] && [ "$1" 
 
 elif [ "$1" = "--down" ]; then
     # If --down is passed, bring down the Docker containers
-    echo -e "${GREEN}Bringing down the Docker containers... ${NC}"
+    echo -e "${YELLOW}Bringing down the Docker containers... ${NC}"
     docker compose -f docker/compose.base.yaml -f docker/compose.summary.yaml -f docker/compose.search.yaml --profile ovms down
+    if [ $? -ne 0 ]; then
+        echo -e "${RED}ERROR: Failed to stop and remove containers.${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}All containers were successfully stopped and removed. ${NC}"
     return 0
 fi
 
@@ -176,13 +188,6 @@ export UI_PM_ENDPOINT=${UI_PM_ENDPOINT:-/manager}
 export UI_ASSETS_ENDPOINT=${UI_ASSETS_ENDPOINT:-/datastore}
 
 export CONFIG_SOCKET_APPEND=${CONFIG_SOCKET_APPEND} # Set this to CONFIG_ON in your shell, if nginx not being used
-
-# Directories containing models and various configs for mounting in containers
-export OVMS_CONFIG_DIR=${PWD}/config/ovms_config
-export OV_MODEL_DIR=${PWD}/ov_models
-export CONFIG_DIR=${PWD}/config
-export NGINX_CONFIG=${CONFIG_DIR}/nginx.conf
-export RABBITMQ_CONFIG=${CONFIG_DIR}/rmq.conf
 
 # Object detection model settings
 export OD_MODEL_NAME=${OD_MODEL_NAME}


### PR DESCRIPTION

### Description

- Container down failing because of some required env vars for docker compose not set
- Fixed by allowing setup script to set these vars before trying to down containers
- Added error or success message after running docker compose down
- updated project structure in get-started docs

Fixes # (issue)

Setup script not able to bring down containers if some of the variables are not set.

Fix : Allowed setup script to set these variables before trying to bring down containers.

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Manual test cases for fixes

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

