### PR TITLE
🚑️ fix: Video Search not working with multiple video uploads

### DIFF
--- a/microservices/multimodal-embedding-serving/docker/Dockerfile
+++ b/microservices/multimodal-embedding-serving/docker/Dockerfile
@@ -12,14 +12,14 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missin
 RUN pip install --upgrade --no-cache pip setuptools && \
     pip install --no-cache torch~=2.7.1 torchvision~=0.22.1 --index-url https://download.pytorch.org/whl/cpu;
 
-RUN pip install poetry==1.8.5
+RUN pip install poetry==2.1.3
 
 RUN poetry config virtualenvs.create false
 
 WORKDIR /app
 
 COPY poetry.lock pyproject.toml /app/
-RUN poetry lock --no-update && poetry install --no-root
+RUN poetry lock && poetry install --no-root
 
 RUN apt-get install -y --no-install-recommends curl ca-certificates libxml2 gnupg
 
@@ -44,7 +44,6 @@ RUN apt-get clean && rm -rf /tmp/install_gpu_drivers.sh && rm -rf /var/lib/apt/l
 RUN groupadd -g ${USER_GROUP_ID} appuser && useradd -m -s /bin/bash -u ${USER_ID} -g ${USER_GROUP_ID} appuser
 
 COPY . .
-RUN mkdir -p /tmp/dataprep/videos
 
 # Optionally download copyleft sources if requested
 ARG COPYLEFT_SOURCES=false

--- a/microservices/multimodal-embedding-serving/docker/Dockerfile
+++ b/microservices/multimodal-embedding-serving/docker/Dockerfile
@@ -78,8 +78,8 @@ RUN if [ "$COPYLEFT_SOURCES" = "true" ]; then \
         apt-get remove --purge -y gcc build-essential libffi-dev python3-dev; \
     fi
     
-RUN mkdir -p /home/appuser/.cache/huggingface /app/ov-models && \
-    chown -R appuser:appuser /home/appuser/.cache /app/ov-models
+RUN mkdir -p /home/appuser/.cache/huggingface /app/ov-models /tmp/dataprep && \
+    chown -R appuser:appuser /home/appuser/.cache /app/ov-models /tmp/dataprep
 
 USER appuser
 

--- a/microservices/multimodal-embedding-serving/docker/compose.yaml
+++ b/microservices/multimodal-embedding-serving/docker/compose.yaml
@@ -26,8 +26,8 @@ services:
       DEBUG_MODE: ${DEBUG_MODE:-False}
     group_add:
       - ${USER_GROUP_ID-1000}
-      - ${VIDEO_GROUP_ID}
-      - ${RENDER_GROUP_ID}
+      - ${VIDEO_GROUP_ID-44}
+      - ${RENDER_GROUP_ID-1002}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]

--- a/microservices/multimodal-embedding-serving/docker/compose.yaml
+++ b/microservices/multimodal-embedding-serving/docker/compose.yaml
@@ -25,9 +25,9 @@ services:
       EMBEDDING_DEVICE: ${EMBEDDING_DEVICE}
       DEBUG_MODE: ${DEBUG_MODE:-False}
     group_add:
-      - ${USER_GROUP_ID-1000}
-      - ${VIDEO_GROUP_ID-44}
-      - ${RENDER_GROUP_ID-1002}
+      - ${USER_GROUP_ID:-1000}
+      - ${VIDEO_GROUP_ID:-44}
+      - ${RENDER_GROUP_ID:-1002}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]

--- a/microservices/visual-data-preparation-for-retrieval/vdms/docker/Dockerfile
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/docker/Dockerfile
@@ -77,7 +77,9 @@ RUN chmod +x /entrypoint.sh
 
 # Source code will be mounted here
 WORKDIR /app
-RUN mkdir -p /tmp/dataprep/videos
+
+# Create temporary directory to store app artifacts. Ownership is changed to appuser later.
+RUN mkdir -p /tmp/dataprep
 
 # Set ownership of directories to appuser
 RUN chown -R appuser:appuser /app /tmp/dataprep /entrypoint.sh
@@ -161,10 +163,12 @@ RUN if [ "$COPYLEFT_SOURCES" = "true" ]; then \
     fi
 
 WORKDIR /app
-RUN mkdir -p /tmp/dataprep/videos
+
+# Create temporary directory to store app artifacts. Ownership is changed to appuser later.
+RUN mkdir -p /tmp/dataprep
 
 # Set ownership of all necessary directories to appuser
-RUN chown -R appuser:appuser /app /entrypoint.sh
+RUN chown -R appuser:appuser /app  /tmp/dataprep /entrypoint.sh
 
 # Switch to non-root user
 USER appuser

--- a/microservices/visual-data-preparation-for-retrieval/vdms/setup.sh
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/setup.sh
@@ -58,8 +58,8 @@ echo "Using Registry : ${REGISTRY}"
 # -----------------------------------------------------------------------------------------
 
 # Check if MINIO credentials are set
-# Only check MinIO credentials if we're not just stopping containers 
-if [ "$1" != "--down" ]; then
+# Only check MinIO credentials if we're not just stopping containers or building images
+if [ "$1" != "--down" ] && [ "$1" != "--build" ] && [ "$1" != "--build-dev" ] && [ "$1" != "--build-test" ] && [ "$1" != "--build-lint" ]; then
     if [ -z "$MINIO_ROOT_USER" ]; then
         echo -e "${RED}ERROR: MINIO_ROOT_USER is not set in environment.${NC}"
         return

--- a/microservices/visual-data-preparation-for-retrieval/vdms/src/core/embedding/__init__.py
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/src/core/embedding/__init__.py
@@ -4,12 +4,12 @@
 from .embedding_api import vCLIPEmbeddings
 from .embedding_helper import generate_text_embedding, generate_video_embedding
 from .embedding_model import Qwen3, vCLIP
-from .embedding_service import vCLIPEmbeddingServiceWrapper
+from .embedding_service import EmbeddingServiceWrapper
 
 __all__ = [
     "generate_text_embedding",
     "generate_video_embedding",
-    "vCLIPEmbeddingServiceWrapper",
+    "EmbeddingServiceWrapper",
     "vCLIPEmbeddings",
     "vCLIP",
     "Qwen3",

--- a/microservices/visual-data-preparation-for-retrieval/vdms/src/core/embedding/embedding_service.py
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/src/core/embedding/embedding_service.py
@@ -10,8 +10,8 @@ from pydantic import BaseModel
 from src.common import Strings, logger, settings
 
 
-class vCLIPEmbeddingServiceWrapper(BaseModel, Embeddings):
-    """Wrapper for vCLIP Embeddings that makes API calls to /embeddings endpoint."""
+class EmbeddingServiceWrapper(BaseModel, Embeddings):
+    """Wrapper for External Embedding Service that makes API calls to /embeddings endpoint."""
 
     api_url: str
     model_name: str

--- a/microservices/visual-data-preparation-for-retrieval/vdms/src/endpoints/document_processing/process_text.py
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/src/endpoints/document_processing/process_text.py
@@ -85,6 +85,8 @@ async def process_video_summary(
        - **video_summary (str) :** The text summary for the video to be embedded
        - **video_start_time (float) :** The start timestamp in seconds for the video or video chunk
        - **video_end_time (float) :** The end timestamp in seconds for the video or video chunk
+       - **tags (list(str), optional) :** A list of tags to be associated with the video. Useful for filtering the search.
+       
     #### Raises:
     - **400 Bad Request :** If required parameters are missing or invalid.
     - **404 Not Found :** If the specified video cannot be found in Minio.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/src/endpoints/video_processing/process_minio_video.py
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/src/endpoints/video_processing/process_minio_video.py
@@ -99,6 +99,7 @@ async def process_minio_video(
        - **video_name (str, optional) :** The video filename within the video_id directory (if omitted, the first MP4 video found in the directory will be used automatically)
        - **chunk_duration (int) :** Interval of time in seconds for video chunking (default: 30)
        - **clip_duration (int) :** Length of clip in seconds for embedding selection (default: 10)
+       - **tags (list(str), optional) :** A list of tags to be associated with the video. Useful for filtering the search.
 
     #### Raises:
     - **400 Bad Request :** If required parameters are missing or invalid.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/src/endpoints/video_processing/upload_and_process_video.py
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/src/endpoints/video_processing/upload_and_process_video.py
@@ -70,6 +70,7 @@ async def upload_and_process_video(
     - **bucket_name (str, optional) :** The bucket name to store the video in. If not provided, default bucket will be used.
     - **chunk_duration (int, optional) :** Interval of time in seconds for video chunking (default: 30)
     - **clip_duration (int, optional) :** Length of clip in seconds for embedding selection (default: 10)
+    - **tags (list(str), optional) :** A list of tags to be associated with the video. Useful for filtering the search.
 
     #### Raises:
     - **400 Bad Request :** If the video file is not an MP4 or fails validation.

--- a/microservices/vlm-openvino-serving/docker/compose.yaml
+++ b/microservices/vlm-openvino-serving/docker/compose.yaml
@@ -31,9 +31,9 @@ services:
     devices:
       - /dev/dri:/dev/dri
     group_add:
-      - ${USER_GROUP_ID-1000} 
-      - ${VIDEO_GROUP_ID}    
-      - ${RENDER_GROUP_ID} 
+      - ${USER_GROUP_ID:-1000} 
+      - ${VIDEO_GROUP_ID:-44}    
+      - ${RENDER_GROUP_ID:-1002}
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
       interval: 10s

--- a/sample-applications/video-search-and-summarization/docker/compose.search.yaml
+++ b/sample-applications/video-search-and-summarization/docker/compose.search.yaml
@@ -133,9 +133,9 @@ services:
     devices:
       - /dev/dri:/dev/dri
     group_add:
-      - ${USER_GROUP_ID-1000}
-      - ${VIDEO_GROUP_ID-44}
-      - ${RENDER_GROUP_ID-1002}
+      - ${USER_GROUP_ID:-1000}
+      - ${VIDEO_GROUP_ID:-44}
+      - ${RENDER_GROUP_ID:-1002}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]

--- a/sample-applications/video-search-and-summarization/docker/compose.summary.yaml
+++ b/sample-applications/video-search-and-summarization/docker/compose.summary.yaml
@@ -72,9 +72,9 @@ services:
     devices:
       - /dev/dri:/dev/dri
     group_add:
-      - ${USER_GROUP_ID-1000} 
-      - ${VIDEO_GROUP_ID-44}    
-      - ${RENDER_GROUP_ID-1002}
+      - ${USER_GROUP_ID:-1000} 
+      - ${VIDEO_GROUP_ID:-44}    
+      - ${RENDER_GROUP_ID:-1002}
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
       interval: 10s

--- a/sample-applications/video-search-and-summarization/search-ms/docker/Dockerfile
+++ b/sample-applications/video-search-and-summarization/search-ms/docker/Dockerfile
@@ -3,14 +3,19 @@
 
 FROM python:3.12.10-slim AS build
 
-RUN pip install poetry==1.8.5
+ARG USER_ID=1000
+ARG USER_GROUP_ID=1000
+
+RUN groupadd -g ${USER_GROUP_ID} appuser && useradd -m -s /bin/bash -u ${USER_ID} -g ${USER_GROUP_ID} appuser
+
+RUN pip install poetry==2.1.3
 
 RUN poetry config virtualenvs.create false
 
 WORKDIR /app
 
 COPY poetry.lock pyproject.toml /app/
-RUN poetry lock --no-update && poetry install --no-root
+RUN poetry lock && poetry install --no-root
 
 COPY . .
 
@@ -47,8 +52,10 @@ RUN if [ "$COPYLEFT_SOURCES" = "true" ]; then \
         apt-get remove --purge -y gcc build-essential libffi-dev python3-dev; \
     fi
     
-RUN mkdir -p /tmp/watcher-dir
+RUN mkdir -p /tmp/watcher-dir && chmod 775 /tmp/watcher-dir && chown -R appuser:appuser /app
+
+USER appuser
+
 EXPOSE 8000
 
 CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "debug"]
-


### PR DESCRIPTION
### Description

Fixes # (issue)

Fix for video search considering only the first video being uploaded.

#### Root Cause

Side-effects of Caching the VDMS Client object instantiation for implementing singleton pattern.

#### Fix

Updated the  VDMS Client Constructor and added new parameters to methods to accept new metadata.

#### Other Updates

    - Updated dataprep and mme dockerfile to handle /tmp/dataprep directory permissions properly
    - Updated poetry version and permission fixes to video search dockerfile
    - Minor refactoring in vdms-dataprep
    - Updated setup script for vdsm-dataprep to not look for minio credentials while building image

### Any Newly Introduced Dependencies

Version upgrade for Poetry Package in MME Service and Video-Search Service

### How Has This Been Tested?

Manually tested for all relevant use cases.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

