### PR TITLE
🚑️ Hotfix: Docker setup - Previous Summary/Search results not persisting

### DIFF
--- a/sample-applications/video-search-and-summarization/docker/compose.base.yaml
+++ b/sample-applications/video-search-and-summarization/docker/compose.base.yaml
@@ -99,6 +99,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+      PGDATA: /var/lib/postgresql/data/pgdata
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 30s
@@ -142,9 +143,6 @@ volumes:
     driver: local
   pg_data:
     driver: local
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
 networks:
   vs_network:
     driver: bridge


### PR DESCRIPTION
### Bug Description

In Docker setup, once the containers were brought down, records of search queries, results and summaries are gone.

#### Root Cause

Postgres container was using a non-persistent `tmpfs` volume, which keeps the the volume data in volatile memory instead of disk. Also, a required PGDATA variable was not set for PostgreSQL container, which tells PostgreSQL about the location of its DATA DIR.


### Fix

- Updated docker volume driver for postgres volume to not use tmpfs
- Provided PGDATA env var to pgsql container to let it know where the data dir is


### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Manually verified end to end for persistence of search results and summaries.
### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

