### PR TITLE
Fix: VSS with search tag feature is working now

### DIFF
--- a/sample-applications/video-search-and-summarization/pipeline-manager/src/data-prep/models/data-prep.models.ts
+++ b/sample-applications/video-search-and-summarization/pipeline-manager/src/data-prep/models/data-prep.models.ts
@@ -6,6 +6,7 @@ export interface DataPrepMinioDTO {
   video_name: string;
   chunk_duration?: number;
   clip_duration?: number;
+  tags?: string[];
 }
 
 export interface DataPrepSummaryDTO {

--- a/sample-applications/video-search-and-summarization/pipeline-manager/src/video-upload/services/video.service.ts
+++ b/sample-applications/video-search-and-summarization/pipeline-manager/src/video-upload/services/video.service.ts
@@ -50,6 +50,7 @@ export class VideoService {
       bucket_name: video.dataStore.bucket,
       video_id: video.dataStore?.objectName,
       video_name: video.dataStore?.fileName,
+      tags: video.tags || [],
     };
 
     return await lastValueFrom(this.$dataprep.createEmbeddings(videoData));


### PR DESCRIPTION
### Description

This PR enables tag-based video search functionality in the Video Search & Summarization application. The main change is ensuring that video tags are passed from the pipeline manager to the VDMS data preparation service when creating search embeddings. This allows the search service to filter and return videos based on tags as expected in --search mode.

Fixes # (issue)

Resolves the issue where searching by tag in --search mode returned no results, even when videos had tags assigned.

### Any Newly Introduced Dependencies

No 

### How Has This Been Tested?

Uploaded videos with tags using the UI and API locally.
Performed searches using tags in --search mode and verified that videos with matching tags are returned.
Ran the application in Docker Compose and tested end-to-end functionality.

### Checklist:

- [✓ ] I agree to use the APACHE-2.0 license for my code changes.
- [✓ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [✓ ] I have not included any company confidential information, trade secret, password or security token. 
- [✓ ] I have performed a self-review of my code.

